### PR TITLE
fix: idDuplicateCheck 메소드의 검증 결과 추가

### DIFF
--- a/server/src/main/java/com/taxisharing/server/user/controller/UserController.java
+++ b/server/src/main/java/com/taxisharing/server/user/controller/UserController.java
@@ -24,9 +24,9 @@ public class UserController {
     private final UserRepository userRepository;
 
     @GetMapping()
-    ResponseEntity<IdDuplicateResponse> idDuplicateCheck(@Valid @RequestParam("username") IdDuplicateRequest idDuplicateRequest)
+    ResponseEntity<IdDuplicateResponse> idDuplicateCheck(@Valid @RequestParam("username") IdDuplicateRequest idDuplicateRequest, BindingResult result)
     {
-        if(userRepository.existsByUsername(idDuplicateRequest.getUsername()))
+        if(result.hasErrors() || userRepository.existsByUsername(idDuplicateRequest.getUsername()))
         {
             throw new DuplicatedUsernameException();
         }


### PR DESCRIPTION
Valid 옵션을 넣었지만 결과를 사용안하는 문제를 고침